### PR TITLE
ci: Do not require secret

### DIFF
--- a/.github/workflows/release-python-package.yaml
+++ b/.github/workflows/release-python-package.yaml
@@ -59,7 +59,7 @@ on:
         type: boolean
     secrets:
       GH_TOKEN:
-        required: true
+        required: false
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
We only need the GH_TOKEN secret if using maturin to pull in build dependencies.