### PR TITLE
Allow specifying branch of helm-configuration repo

### DIFF
--- a/.github/workflows/deploy-any-branch-dev.yaml
+++ b/.github/workflows/deploy-any-branch-dev.yaml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         description: Application name
+      helm_repo_branch:
+        required: false
+        type: string
+        default: main
+        description: Branch of helm-configuration repo to use
     secrets:
       app_id:
         required: true
@@ -53,7 +58,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: propeller-heads/helm-configuration
-          ref: main
+          ref: "${{ inputs.helm_repo_branch }}"
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install yq


### PR DESCRIPTION
This will be useful until the branch for the new cluster gets merged to main.