### PR TITLE
TRB-353: remove hardcode CVM type in the gateway_domain var

### DIFF
--- a/.github/workflows/deploy-turbine.yaml
+++ b/.github/workflows/deploy-turbine.yaml
@@ -109,11 +109,16 @@ jobs:
           echo RUST_LOG=${{ inputs.rust_log }} >> .env
           echo DOCKER_IMAGE_TAG=${{ inputs.image_tag }} >> .env
           echo FRONTEND_URL=${{ inputs.frontend_url }} >> .env
-          echo GATEWAY_DOMAIN=${{ inputs.gateway_domain }} >> .env
           CVM_ID=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .hosted.app_id'`
+          CVM_TYPE=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .node.name'`
+          echo GATEWAY_DOMAIN=_.dstack-$CVM_TYPE.phala.network >> .env
           if [ -z "$CVM_ID" ]; then
             echo "CVM is not found. Creating..."
             phala cvms create -c ./docker-compose-dstack.yaml -n ${{ inputs.cvm_name }} -e ./.env
+            sleep 30
+            CVM_TYPE=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .node.name'`
+            echo GATEWAY_DOMAIN=_.dstack-$CVM_TYPE.phala.network >> .env
+            phala cvms upgrade $CVM_ID -c ./docker-compose-dstack.yaml -e ./.env
           else
             echo "CVM is found. Upgrading..."
             phala cvms upgrade $CVM_ID -c ./docker-compose-dstack.yaml -e ./.env

--- a/.github/workflows/deploy-turbine.yaml
+++ b/.github/workflows/deploy-turbine.yaml
@@ -110,7 +110,7 @@ jobs:
           if [ -z "$CVM_ID" ]; then
             echo "CVM is not found. Creating..."
             phala cvms create -c ./docker-compose-dstack.yaml -n ${{ inputs.cvm_name }} -e ./.env
-            sleep 30
+            sleep 10
             CVM_ID=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .hosted.app_id'`
             CVM_TYPE=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .node.name'`
             echo GATEWAY_DOMAIN=_.dstack-$CVM_TYPE.phala.network >> .env

--- a/.github/workflows/deploy-turbine.yaml
+++ b/.github/workflows/deploy-turbine.yaml
@@ -106,7 +106,6 @@ jobs:
           echo DOCKER_IMAGE_TAG=${{ inputs.image_tag }} >> .env
           echo FRONTEND_URL=${{ inputs.frontend_url }} >> .env
           CVM_ID=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .hosted.app_id'`
-          CVM_TYPE=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .node.name'`
           if [ -z "$CVM_ID" ]; then
             echo "CVM is not found. Creating..."
             phala cvms create -c ./docker-compose-dstack.yaml -n ${{ inputs.cvm_name }} -e ./.env
@@ -117,6 +116,7 @@ jobs:
             phala cvms upgrade $CVM_ID -c ./docker-compose-dstack.yaml -e ./.env
           else
             echo "CVM is found. Upgrading..."
+            CVM_TYPE=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .node.name'`
             echo GATEWAY_DOMAIN=_.dstack-$CVM_TYPE.phala.network >> .env
             phala cvms upgrade $CVM_ID -c ./docker-compose-dstack.yaml -e ./.env
           fi

--- a/.github/workflows/deploy-turbine.yaml
+++ b/.github/workflows/deploy-turbine.yaml
@@ -116,6 +116,7 @@ jobs:
             echo "CVM is not found. Creating..."
             phala cvms create -c ./docker-compose-dstack.yaml -n ${{ inputs.cvm_name }} -e ./.env
             sleep 30
+            CVM_ID=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .hosted.app_id'`
             CVM_TYPE=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .node.name'`
             echo GATEWAY_DOMAIN=_.dstack-$CVM_TYPE.phala.network >> .env
             phala cvms upgrade $CVM_ID -c ./docker-compose-dstack.yaml -e ./.env

--- a/.github/workflows/deploy-turbine.yaml
+++ b/.github/workflows/deploy-turbine.yaml
@@ -41,10 +41,6 @@ on:
         required: true
         type: string
         description: Public domain for service
-      gateway_domain:
-        required: true
-        type: string
-        description: Internal domain of PhalaCloud CVM
     secrets:
       aws_region:
         required: true

--- a/.github/workflows/deploy-turbine.yaml
+++ b/.github/workflows/deploy-turbine.yaml
@@ -111,7 +111,6 @@ jobs:
           echo FRONTEND_URL=${{ inputs.frontend_url }} >> .env
           CVM_ID=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .hosted.app_id'`
           CVM_TYPE=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .node.name'`
-          echo GATEWAY_DOMAIN=_.dstack-$CVM_TYPE.phala.network >> .env
           if [ -z "$CVM_ID" ]; then
             echo "CVM is not found. Creating..."
             phala cvms create -c ./docker-compose-dstack.yaml -n ${{ inputs.cvm_name }} -e ./.env
@@ -122,5 +121,6 @@ jobs:
             phala cvms upgrade $CVM_ID -c ./docker-compose-dstack.yaml -e ./.env
           else
             echo "CVM is found. Upgrading..."
+            echo GATEWAY_DOMAIN=_.dstack-$CVM_TYPE.phala.network >> .env
             phala cvms upgrade $CVM_ID -c ./docker-compose-dstack.yaml -e ./.env
           fi


### PR DESCRIPTION
In the previous version of deploying script, we pass **gateway_domain**=**_.dstack-prod4.phala.network** from the parent pipeline.  And in the case of creating new CVM(not upgrading existing) it can lead to troubles, cause we can't be confident that new CVM will be with **prod4** type of CVM. From the PhalaCloud documentation I couldn't find anything related to configuration of CVM before apply via CLI, there is only info how make it via Web UI.
So, I think the best approach when we need to create new CVM is to create it, get the type of CVM, rewrite our **gateway_domain** with updated CVM type and then upgrade recently created CVM. It allows us to be independent from the CVM type.