### PR TITLE
fix: Update turbine image name

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yaml
+++ b/.github/workflows/build-and-push-docker-image.yaml
@@ -150,7 +150,7 @@ jobs:
           cargo fetch
 
       - name: Get Speedex binary
-        if: "${{ inputs.image_name == 'turbine-rust' && steps.check-image.outputs.skip_remaining_steps != 'true' }}"
+        if: "${{ inputs.image_name == 'turbine' && steps.check-image.outputs.skip_remaining_steps != 'true' }}"
         run: |
           mkdir -p src/clearing_algorithm/speedex/bin
           aws s3 cp s3://propellerheads-speedex/propeller_speedex_amd src/clearing_algorithm/speedex/bin/propeller_speedex


### PR DESCRIPTION
We no longer use `turbine-rust` but `turbine`