### PR TITLE
feat: Remove frontend url from turbine deployment workflow

### DIFF
--- a/.github/workflows/deploy-turbine.yaml
+++ b/.github/workflows/deploy-turbine.yaml
@@ -25,10 +25,6 @@ on:
         required: true
         type: string
         description: CVM name
-      frontend_url:
-        required: true
-        type: string
-        description: URL of the frontend
       image_tag:
         required: true
         type: string
@@ -106,7 +102,6 @@ jobs:
           echo DOMAIN=${{ inputs.domain }} >> .env
           echo RUST_LOG=${{ inputs.rust_log }} >> .env
           echo DOCKER_IMAGE_TAG=${{ inputs.image_tag }} >> .env
-          echo FRONTEND_URL=${{ inputs.frontend_url }} >> .env
           CVM_ID=`phala cvms ls -j | tail -n +2 | jq -r '.[] | select(.hosted.name == "'${{ inputs.cvm_name }}'") | .hosted.app_id'`
           if [ -z "$CVM_ID" ]; then
             echo "CVM is not found. Creating..."


### PR DESCRIPTION
It was somehow wrongly used. We have correct allowed origins included in config files anyway.