### PR TITLE
ci: change ci/cd to deploy defined services from helm-configuration for dev env

### DIFF
--- a/.github/workflows/deploy-any-branch-dev.yaml
+++ b/.github/workflows/deploy-any-branch-dev.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Replace release version
         run: |
-          yq eval '.${{ inputs.app_name || inputs.image_name }}.tag="${{ inputs.image_tag }}"' -i helmwave/dev/versions.yml
+          yq eval '.${{ inputs.image_name }}.tag="${{ inputs.image_tag }}"' -i helmwave/dev/versions.yml
           cat helmwave/dev/versions.yml
 
       - name: Deploy app using helmwave


### PR DESCRIPTION
Issue: we use pipeline **deploy-any-branch-dev.yaml** for deploy to dev env. In some repos like _defibot_, _tycho-indexer_ - there is case when you can define which app you want to deploy(you can choose it, when you start ci/cd). But we have a problem that in the helm-configuration repo there are some default values where was defined fileds from which registry and which tag it will be deployed.
For example, repo - [tycho-indexer](https://github.com/propeller-heads/tycho-indexer/tree/main).
Here you can choose which app you want to deploy: 
- tycho-indexer
- arbitrum-tycho-indexer
- ethereum-tycho-indexer
- base-tycho-indexer

But if you try to deploy **ethereum-tycho-indexer** app for example, it will not work correctly - because ci/cd will change tag in the filed **ethereum-tycho-indexer** at the  file _helmwave/dev/versions.yml_ , but in the helm-configuration repo we have a file with default values **_common-tycho-indexer.yml** for apps from the list above, where we use instruction to get tag from the field **tycho-indexer**, not **ethereum-tycho-indexer**. It means that everytime you want to change version only for **ethereum-tycho-indexer** app - you will get the same version of tag from the field **tycho-indexer**, which you don't change. 

So, in that case to have possibility to change only defined service from the list - we will change tag in the field **tycho-indexer**, and deploy only defined service via helmwave command.

Now, ci/cd will change tag for common field, which we use at the file **_common-tycho-indexer.yml**, but deploy only defined service via command `helmwave up --build -t ${{ inputs.app_name || inputs.image_name }}`, where `${{ inputs.app_name }}` - name of defined service.