### PR TITLE
feat(docker): add optional dockerfile input to build-and-push workflow

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yaml
+++ b/.github/workflows/build-and-push-docker-image.yaml
@@ -36,6 +36,11 @@ on:
       tycho_client_version:
         type: string
         required: false
+      dockerfile:
+        required: false
+        type: string
+        default: Dockerfile
+        description: Path to the Dockerfile, relative to the repository root
       build_tool:
         required: false
         type: string
@@ -169,6 +174,7 @@ jobs:
         with:
           push: true
           tags: ${{ secrets.repository_url }}/${{ inputs.image_name }}:${{ inputs.image_tag }}
+          dockerfile: ${{ inputs.dockerfile }}
           cache: "${{ inputs.cache }}"
           cache-repository: "${{ secrets.repository_url }}/${{ inputs.image_name }}"
           build-args: |
@@ -188,6 +194,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
         with:
           context: .
+          file: ${{ inputs.dockerfile }}
           push: true
           tags: ${{ secrets.repository_url }}/${{ inputs.image_name }}:${{ inputs.image_tag }}
           build-args: |


### PR DESCRIPTION
## Summary

- Adds an optional `dockerfile` input to the `build-and-push-docker-image.yaml` reusable workflow
- Default is `Dockerfile` (repo root), so all existing callers are unaffected
- Wired to both build paths: `dockerfile:` for kaniko, `file:` for docker buildx

## Motivation

Callers with non-standard Dockerfile locations (e.g. `docker/tycho-indexer.Dockerfile`) had no way to specify the path. Passing an undefined input to a reusable workflow causes a hard GitHub Actions validation error.

## Backwards compatibility

Fully backwards compatible — the input is optional with a default matching the previous implicit behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)