### PR TITLE
fix(docker): pass dockerfile path to kaniko as 'file' not 'dockerfile'

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yaml
+++ b/.github/workflows/build-and-push-docker-image.yaml
@@ -174,7 +174,7 @@ jobs:
         with:
           push: true
           tags: ${{ secrets.repository_url }}/${{ inputs.image_name }}:${{ inputs.image_tag }}
-          dockerfile: ${{ inputs.dockerfile }}
+          file: ${{ inputs.dockerfile }}
           cache: "${{ inputs.cache }}"
           cache-repository: "${{ secrets.repository_url }}/${{ inputs.image_name }}"
           build-args: |


### PR DESCRIPTION
int128/kaniko-action does not accept a 'dockerfile' input — the correct key is 'file'. Passing 'dockerfile' produced a warning and was silently ignored, causing kaniko to fall back to the default 'Dockerfile' in the repo root regardless of the input value:

  Unexpected input(s) 'dockerfile', valid inputs are ['executor', 'cache',
  'cache-repository', 'cache-ttl', 'push-retry', 'registry-mirror',
  'verbosity', 'kaniko-args', 'docker-run-args', 'build-args', 'context',
  'file', 'labels', 'push', 'tags', 'target']