### PR TITLE
feat(docker): add kaniko verbosity input to build-and-push workflow

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yaml
+++ b/.github/workflows/build-and-push-docker-image.yaml
@@ -45,6 +45,11 @@ on:
         required: false
         type: string
         default: kaniko
+      kaniko_verbosity:
+        required: false
+        type: string
+        default: info
+        description: Verbosity level for kaniko (e.g. debug, info, warn, error, fatal, panic)
     secrets:
       app_id:
         required: true
@@ -180,7 +185,7 @@ jobs:
           build-args: |
             PIP_INDEX_URL=${{ env.PIP_INDEX_URL }}
             ${{ inputs.build_args }}
-          #verbosity: DEBUG
+          verbosity: ${{ inputs.kaniko_verbosity }}
         env:
           SOURCE_DATE_EPOCH: 0
 


### PR DESCRIPTION
Introduces a new optional input `kaniko_verbosity` to specify the verbosity level for kaniko during the build process. This allows users to customize logging output (e.g., debug, info, warn, error, fatal, panic) for better visibility into the build process.