### PR TITLE
ci: add release-v3 PR-based release workflow (release-please)

### DIFF
--- a/.github/workflows/release-v3.yaml
+++ b/.github/workflows/release-v3.yaml
@@ -1,0 +1,255 @@
+name: Release v3 (PR-based)
+
+# PR-based release flow. Unlike release-v2 (which pushes the version bump + CHANGELOG
+# straight to main via semantic-release + @semantic-release/git), v3 never writes to main.
+#
+# Phase A (prepare) — runs on a normal push to main:
+#   * computes the next version with `semantic-release --dry-run`
+#   * closes any stale open release PR (label: autorelease) and deletes its branch
+#   * recreates the bump + CHANGELOG on an `autorelease/v<version>` branch, reusing the
+#     repo's own `@semantic-release/exec` prepareCmd (no duplication)
+#   * opens a fresh release PR for human review
+#
+# Phase B (publish) — runs when the release commit (`chore(release): <version>`) lands on
+# main via the merged release PR:
+#   * creates the tag + GitHub Release, which triggers the repo's existing
+#     `release: published` publish workflows (crates.io, npm, binaries, images)
+#
+# The App token only ever pushes to `autorelease/*` branches and opens/closes PRs — it
+# never commits to main — so the App can be removed from the main-branch ruleset bypass.
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        required: false
+        type: string
+        default: ubuntu-latest
+      timeout_minutes:
+        required: false
+        type: number
+        default: 30
+      node_version:
+        required: false
+        type: string
+        default: "20.11.1"
+      python_version:
+        required: false
+        type: string
+        default: "3.12"
+      args:
+        description: Extra flags forwarded to `semantic-release --dry-run` (e.g. --tag-format).
+        required: false
+        type: string
+        default: ""
+      tag_prefix:
+        description: Prefix prepended to the version to form the git tag (e.g. keygen-v).
+        required: false
+        type: string
+        default: ""
+    secrets:
+      app_id:
+        required: true
+      app_private_key:
+        required: true
+    outputs:
+      next_release_version:
+        description: The released version (publish) or the pending version (prepare); empty if no release.
+        value: ${{ jobs.release.outputs.next_release_version }}
+      released:
+        description: "true when this run published a release (Phase B)."
+        value: ${{ jobs.release.outputs.released }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    outputs:
+      next_release_version: ${{ steps.version.outputs.value }}
+      released: ${{ steps.detect.outputs.phase == 'publish' }}
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Detect release phase
+        id: detect
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # A push whose new commits include a `chore(release): <version>` commit is the
+          # merge of a release PR -> publish. Anything else -> prepare a release PR.
+          if [ -z "${BEFORE:-}" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            msgs=$(git log -1 --format=%s "$AFTER")
+          else
+            msgs=$(git log --format=%s "${BEFORE}..${AFTER}")
+          fi
+          marker=$(printf '%s\n' "$msgs" | grep -m1 '^chore(release): ' || true)
+          if [ -n "$marker" ]; then
+            version=$(printf '%s' "$marker" | sed -E 's/^chore\(release\): ([^ ]+).*/\1/')
+            {
+              echo "phase=publish"
+              echo "version=$version"
+            } >> "$GITHUB_OUTPUT"
+            echo "Release commit detected (version $version) -> publish phase"
+          else
+            echo "phase=prepare" >> "$GITHUB_OUTPUT"
+            echo "No release commit in push -> prepare phase"
+          fi
+
+      # ───────────────────────── Phase B: publish ─────────────────────────
+      - name: Create tag and GitHub Release
+        if: steps.detect.outputs.phase == 'publish'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.detect.outputs.version }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
+        run: |
+          set -euo pipefail
+          tag="${TAG_PREFIX}${VERSION}"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists; nothing to publish."
+            exit 0
+          fi
+          notes_file="$(mktemp)"
+          if [ -f CHANGELOG.md ]; then
+            # Grab the newest version section (first version header up to the next one).
+            awk '/^#{1,3} \[?[0-9]/{n++; if (n>1) exit} n>=1{print}' CHANGELOG.md > "$notes_file" || true
+          fi
+          if [ -s "$notes_file" ]; then
+            gh release create "$tag" --target main --title "$tag" --notes-file "$notes_file"
+          else
+            gh release create "$tag" --target main --title "$tag" --generate-notes
+          fi
+          echo "Published release ${tag}"
+
+      # ───────────────────────── Phase A: prepare ─────────────────────────
+      - name: Setup Node.js
+        if: steps.detect.outputs.phase == 'prepare'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Setup Python
+        if: steps.detect.outputs.phase == 'prepare'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install tooling
+        if: steps.detect.outputs.phase == 'prepare'
+        run: |
+          set -euo pipefail
+          pip install toml-cli
+          npm install --save-dev \
+            semver@7.6.3 \
+            semantic-release@23.0.2 \
+            @semantic-release/changelog@6.0.3 \
+            @semantic-release/git@10.0.1 \
+            @semantic-release/exec@6.0.3 \
+            conventional-changelog-conventionalcommits@7.0.2 \
+            conventional-changelog-eslint@5.0.0 \
+            conventional-changelog-cli@5.0.0 \
+            --legacy-peer-deps
+
+      - name: Compute next version (dry-run)
+        id: dryrun
+        if: steps.detect.outputs.phase == 'prepare'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # The repo's release.config.js verifyReleaseCmd writes VERIFY_RELEASE_VERSION to
+          # this step's $GITHUB_OUTPUT. It stays empty when no release is warranted.
+          npx semantic-release --dry-run ${{ inputs.args }}
+
+      - name: Open release PR
+        if: steps.detect.outputs.phase == 'prepare' && steps.dryrun.outputs.VERIFY_RELEASE_VERSION != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.dryrun.outputs.VERIFY_RELEASE_VERSION }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # 1. Close any stale open release PRs (and delete their branches) so at most one
+          #    release PR exists at a time. Done before pushing the new branch to avoid
+          #    deleting the branch we are about to create.
+          gh label create autorelease --color FBCA04 --description "Automated release PR" --force >/dev/null 2>&1 || true
+          for n in $(gh pr list --label autorelease --state open --json number --jq '.[].number'); do
+            echo "Closing stale release PR #${n}"
+            gh pr close "$n" --delete-branch || true
+          done
+
+          # 2. Recreate the version bump + CHANGELOG on a fresh branch, reusing the repo's
+          #    own prepareCmd (extracted from release.config.js — single source of truth).
+          branch="autorelease/v${VERSION}"
+          git switch -c "$branch"
+          if [ -f release.config.js ]; then
+            # The node script intentionally contains the literal JS string
+            # "${nextRelease.version}" (the placeholder to substitute), not a shell var.
+            # shellcheck disable=SC2016
+            bump="$(VERSION="$VERSION" node -e '
+              const cfg = require(process.cwd() + "/release.config.js");
+              const v = process.env.VERSION;
+              const exec = (cfg.plugins || []).find((p) => Array.isArray(p) && p[0] === "@semantic-release/exec");
+              let c = exec && exec[1] && exec[1].prepareCmd ? exec[1].prepareCmd : "";
+              if (Array.isArray(c)) { c = c.join(" && "); }
+              process.stdout.write(String(c).split("${nextRelease.version}").join(v));
+            ')"
+            if [ -n "$bump" ]; then
+              echo "Applying repo prepare command"
+              bash -c "$bump"
+            fi
+          fi
+
+          # 3. Generate release notes with the same preset semantic-release uses and
+          #    prepend them to CHANGELOG.md.
+          npx conventional-changelog -p conventionalcommits -r 1 > /tmp/notes.md || true
+          if [ -s /tmp/notes.md ]; then
+            touch CHANGELOG.md
+            cat /tmp/notes.md CHANGELOG.md > /tmp/changelog.new
+            mv /tmp/changelog.new CHANGELOG.md
+          fi
+
+          # 4. Commit (no [skip ci] — the merge must trigger the publish phase) and push.
+          git add -A
+          git commit -m "chore(release): ${VERSION}"
+          git push -f origin "$branch"
+
+          # 5. Open the fresh release PR.
+          body_args=(--body "Automated release for version ${VERSION}. Merging this PR tags the release and triggers publishing.")
+          if [ -s /tmp/notes.md ]; then
+            body_args=(--body-file /tmp/notes.md)
+          fi
+          gh pr create --base main --head "$branch" \
+            --title "chore(release): ${VERSION}" \
+            --label autorelease \
+            "${body_args[@]}"
+
+      - name: Resolve output version
+        id: version
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.detect.outputs.phase }}" = "publish" ]; then
+            echo "value=${{ steps.detect.outputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ steps.dryrun.outputs.VERIFY_RELEASE_VERSION }}" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/release-v3.yaml
+++ b/.github/workflows/release-v3.yaml
@@ -1,32 +1,26 @@
-name: Release v3 (PR-based)
+name: Release v3 (release-please)
 
-# PR-based release flow. Unlike release-v2 (which pushes the version bump + CHANGELOG
-# straight to main via semantic-release + @semantic-release/git), v3 never writes to main.
+# PR-based release flow built on release-please. Unlike release-v2 (semantic-release +
+# @semantic-release/git, which pushes the version bump straight to main), v3 opens a
+# release PR for human review and never commits to main.
 #
-# Phase A (prepare) — runs on a normal push to main:
-#   * computes the next version with `semantic-release --dry-run`
-#   * closes any stale open release PR (label: autorelease) and deletes its branch
-#   * recreates the bump + CHANGELOG on an `autorelease/v<version>` branch, reusing the
-#     repo's own `@semantic-release/exec` prepareCmd (no duplication)
-#   * opens a fresh release PR for human review
+# release-please handles both phases in a single run, triggered by the caller's push to
+# main:
+#   * normal push        -> create or update the release PR (version bump + CHANGELOG +
+#                           Cargo.lock, computed from Conventional Commits)
+#   * release PR merged   -> create the tag + GitHub Release, which triggers the repo's
+#                           existing `release: published` publish workflows
 #
-# Phase B (publish) — runs when the release commit (`chore(release): <version>`) lands on
-# main via the merged release PR:
-#   * creates the tag + GitHub Release, which triggers the repo's existing
-#     `release: published` publish workflows (crates.io, npm, binaries, images)
+# It edits manifests/lockfiles directly (no cargo/npm build), so no repository or
+# dependency code runs here and the App token is never exposed to a build script.
 #
-# Token handling (defence in depth — v3 only runs on trusted `push: main`, never fork PRs):
-#   * The App token is scoped to this repository only (create-github-app-token default) and
-#     to the minimum permissions needed (contents + pull-requests write).
-#   * It is minted AFTER all repository code has run, and is exposed only to the git-push /
-#     PR / release steps — never to the `semantic-release`/`cargo`/`npm` steps that execute
-#     repo and dependency code. Those use the default GITHUB_TOKEN (dry-run) or no token.
-#   * checkout uses persist-credentials: false so no token is left on disk during a build.
-#   * The App token is required for push/PR/release specifically because events created with
-#     the default GITHUB_TOKEN do not trigger the downstream publish workflows.
+# Each consumer repo supplies its own `release-please-config.json` and
+# `.release-please-manifest.json`. The App token is used (not the default GITHUB_TOKEN)
+# so the release PR gets CI and the published release triggers downstream workflows —
+# events created with GITHUB_TOKEN do not trigger other workflows.
 #
-# The App token only ever pushes to `autorelease/*` branches and opens/closes PRs — it
-# never commits to main — so the App can be removed from the main-branch ruleset bypass.
+# The App token only opens/updates the release PR and creates the tag/Release — it never
+# commits to main — so the App can be removed from the main-branch ruleset bypass.
 
 on:
   workflow_call:
@@ -35,253 +29,73 @@ on:
         required: false
         type: string
         default: ubuntu-latest
-      timeout_minutes:
-        required: false
-        type: number
-        default: 30
-      node_version:
+      target_branch:
         required: false
         type: string
-        default: "20.11.1"
-      python_version:
+        default: main
+      config_file:
         required: false
         type: string
-        default: "3.12"
-      args:
-        description: Extra flags forwarded to `semantic-release --dry-run` (e.g. --tag-format).
+        default: release-please-config.json
+      manifest_file:
         required: false
         type: string
-        default: ""
-      tag_prefix:
-        description: Prefix prepended to the version to form the git tag (e.g. keygen-v).
-        required: false
-        type: string
-        default: ""
+        default: .release-please-manifest.json
     secrets:
       app_id:
         required: true
       app_private_key:
         required: true
     outputs:
-      next_release_version:
-        description: The released version (publish) or the pending version (prepare); empty if no release.
-        value: ${{ jobs.release.outputs.next_release_version }}
-      released:
-        description: "true when this run published a release (Phase B)."
-        value: ${{ jobs.release.outputs.released }}
+      releases_created:
+        description: "true if any release was created (a release PR was merged this run)."
+        value: ${{ jobs.release-please.outputs.releases_created }}
+      release_created:
+        description: "true if the root component was released."
+        value: ${{ jobs.release-please.outputs.release_created }}
+      tag_name:
+        description: The tag of the created release (empty when no release).
+        value: ${{ jobs.release-please.outputs.tag_name }}
+      version:
+        description: The released version (empty when no release).
+        value: ${{ jobs.release-please.outputs.version }}
+      paths_released:
+        description: JSON array of package paths that were released.
+        value: ${{ jobs.release-please.outputs.paths_released }}
 
-# For the default GITHUB_TOKEN, used only by the semantic-release dry-run (version compute).
-# The privileged operations use the separately-minted, repo-scoped App token below.
+# The default GITHUB_TOKEN is unused: every write goes through the repo-scoped App token.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
-    name: Release
+  release-please:
+    name: Release Please
     runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
-      next_release_version: ${{ steps.version.outputs.value }}
-      released: ${{ steps.detect.outputs.phase == 'publish' }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
+      paths_released: ${{ steps.release.outputs.paths_released }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          fetch-depth: 0
-          # Do not persist any credential on disk: repo/dependency code (cargo, npm) runs
-          # in later steps and must not be able to read a token from .git/config.
-          persist-credentials: false
-
-      - name: Detect release phase
-        id: detect
-        env:
-          BEFORE: ${{ github.event.before }}
-          AFTER: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          # A push whose new commits include a `chore(release): <version>` commit is the
-          # merge of a release PR -> publish. Anything else -> prepare a release PR.
-          if [ -z "${BEFORE:-}" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            msgs=$(git log -1 --format=%s "$AFTER")
-          else
-            msgs=$(git log --format=%s "${BEFORE}..${AFTER}")
-          fi
-          marker=$(printf '%s\n' "$msgs" | grep -m1 '^chore(release): ' || true)
-          if [ -n "$marker" ]; then
-            version=$(printf '%s' "$marker" | sed -E 's/^chore\(release\): ([^ ]+).*/\1/')
-            {
-              echo "phase=publish"
-              echo "version=$version"
-            } >> "$GITHUB_OUTPUT"
-            echo "Release commit detected (version $version) -> publish phase"
-          else
-            echo "phase=prepare" >> "$GITHUB_OUTPUT"
-            echo "No release commit in push -> prepare phase"
-          fi
-
-      # ─────────── Phase A: compute + build the release branch (no App token) ───────────
-      - name: Setup Node.js
-        if: steps.detect.outputs.phase == 'prepare'
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
-        with:
-          node-version: ${{ inputs.node_version }}
-
-      - name: Setup Python
-        if: steps.detect.outputs.phase == 'prepare'
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
-        with:
-          python-version: ${{ inputs.python_version }}
-
-      - name: Install tooling
-        if: steps.detect.outputs.phase == 'prepare'
-        run: |
-          set -euo pipefail
-          pip install toml-cli
-          npm install --save-dev \
-            semver@7.6.3 \
-            semantic-release@23.0.2 \
-            @semantic-release/changelog@6.0.3 \
-            @semantic-release/git@10.0.1 \
-            @semantic-release/exec@6.0.3 \
-            conventional-changelog-conventionalcommits@7.0.2 \
-            conventional-changelog-eslint@5.0.0 \
-            conventional-changelog-cli@5.0.0 \
-            --legacy-peer-deps
-
-      - name: Compute next version (dry-run)
-        id: dryrun
-        if: steps.detect.outputs.phase == 'prepare'
-        env:
-          # Default repo-scoped token, not the App key — this step executes the repo's
-          # release.config.js. It stays empty in VERIFY_RELEASE_VERSION when no release.
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          npx semantic-release --dry-run ${{ inputs.args }}
-
-      - name: Build release branch
-        id: build
-        if: steps.detect.outputs.phase == 'prepare' && steps.dryrun.outputs.VERIFY_RELEASE_VERSION != ''
-        env:
-          # No token in this step: it runs repo + dependency code (cargo, npm scripts).
-          VERSION: ${{ steps.dryrun.outputs.VERIFY_RELEASE_VERSION }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          branch="autorelease/v${VERSION}"
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          git switch -c "$branch"
-
-          # Reuse the repo's own version bump, extracted from release.config.js so there is
-          # a single source of truth.
-          if [ -f release.config.js ]; then
-            # The node script intentionally contains the literal JS string
-            # "${nextRelease.version}" (the placeholder to substitute), not a shell var.
-            # shellcheck disable=SC2016
-            bump="$(VERSION="$VERSION" node -e '
-              const cfg = require(process.cwd() + "/release.config.js");
-              const v = process.env.VERSION;
-              const exec = (cfg.plugins || []).find((p) => Array.isArray(p) && p[0] === "@semantic-release/exec");
-              let c = exec && exec[1] && exec[1].prepareCmd ? exec[1].prepareCmd : "";
-              if (Array.isArray(c)) { c = c.join(" && "); }
-              process.stdout.write(String(c).split("${nextRelease.version}").join(v));
-            ')"
-            if [ -n "$bump" ]; then
-              echo "Applying repo prepare command"
-              bash -c "$bump"
-            fi
-          fi
-
-          # Release notes via the same preset semantic-release uses; prepend to CHANGELOG.
-          npx conventional-changelog -p conventionalcommits -r 1 > /tmp/notes.md || true
-          if [ -s /tmp/notes.md ]; then
-            touch CHANGELOG.md
-            cat /tmp/notes.md CHANGELOG.md > /tmp/changelog.new
-            mv /tmp/changelog.new CHANGELOG.md
-          fi
-
-          # Commit locally (no token needed). No [skip ci]: the merge must trigger publish.
-          git add -A
-          git commit -m "chore(release): ${VERSION}"
-
-      # ─────────── Mint the App token only after all repo code has run ───────────
       - name: Generate app token
         id: app-token
-        if: steps.detect.outputs.phase == 'publish' || steps.dryrun.outputs.VERIFY_RELEASE_VERSION != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.app_private_key }}
-          # Scoped to this repository only (default) and to the minimum permissions needed.
+          # Scoped to this repository only (default) and to the minimum permissions
+          # release-please needs: contents (bump/tag/release), pull-requests (release PR),
+          # issues (manage the autorelease labels).
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
 
-      # ─────────── Phase A: open the release PR (App token, no repo code) ───────────
-      - name: Open release PR
-        if: steps.detect.outputs.phase == 'prepare' && steps.dryrun.outputs.VERIFY_RELEASE_VERSION != ''
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TOKEN: ${{ steps.app-token.outputs.token }}
-          VERSION: ${{ steps.dryrun.outputs.VERIFY_RELEASE_VERSION }}
-          BRANCH: ${{ steps.build.outputs.branch }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          # Close any stale open release PRs (and delete their branches) first, so we never
-          # delete the branch we are about to push.
-          gh label create autorelease --color FBCA04 --description "Automated release PR" --force >/dev/null 2>&1 || true
-          for n in $(gh pr list --label autorelease --state open --json number --jq '.[].number'); do
-            echo "Closing stale release PR #${n}"
-            gh pr close "$n" --delete-branch || true
-          done
-
-          # Push the release branch with the App token via an explicit remote (no persisted
-          # credentials). The token is masked in logs.
-          git push -f "https://x-access-token:${TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${BRANCH}"
-
-          body_args=(--body "Automated release for version ${VERSION}. Merging this PR tags the release and triggers publishing.")
-          if [ -s /tmp/notes.md ]; then
-            body_args=(--body-file /tmp/notes.md)
-          fi
-          gh pr create --base main --head "$BRANCH" \
-            --title "chore(release): ${VERSION}" \
-            --label autorelease \
-            "${body_args[@]}"
-
-      # ─────────── Phase B: publish (App token, no repo code) ───────────
-      - name: Create tag and GitHub Release
-        if: steps.detect.outputs.phase == 'publish'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          VERSION: ${{ steps.detect.outputs.version }}
-          TAG_PREFIX: ${{ inputs.tag_prefix }}
-        run: |
-          set -euo pipefail
-          tag="${TAG_PREFIX}${VERSION}"
-          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
-            echo "Tag ${tag} already exists; nothing to publish."
-            exit 0
-          fi
-          notes_file="$(mktemp)"
-          if [ -f CHANGELOG.md ]; then
-            # Grab the newest version section (first version header up to the next one).
-            awk '/^#{1,3} \[?[0-9]/{n++; if (n>1) exit} n>=1{print}' CHANGELOG.md > "$notes_file" || true
-          fi
-          if [ -s "$notes_file" ]; then
-            gh release create "$tag" --target main --title "$tag" --notes-file "$notes_file"
-          else
-            gh release create "$tag" --target main --title "$tag" --generate-notes
-          fi
-          echo "Published release ${tag}"
-
-      - name: Resolve output version
-        id: version
-        run: |
-          set -euo pipefail
-          if [ "${{ steps.detect.outputs.phase }}" = "publish" ]; then
-            echo "value=${{ steps.detect.outputs.version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=${{ steps.dryrun.outputs.VERIFY_RELEASE_VERSION }}" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Release Please
+        id: release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          config-file: ${{ inputs.config_file }}
+          manifest-file: ${{ inputs.manifest_file }}
+          target-branch: ${{ inputs.target_branch }}

--- a/.github/workflows/release-v3.yaml
+++ b/.github/workflows/release-v3.yaml
@@ -15,6 +15,16 @@ name: Release v3 (PR-based)
 #   * creates the tag + GitHub Release, which triggers the repo's existing
 #     `release: published` publish workflows (crates.io, npm, binaries, images)
 #
+# Token handling (defence in depth — v3 only runs on trusted `push: main`, never fork PRs):
+#   * The App token is scoped to this repository only (create-github-app-token default) and
+#     to the minimum permissions needed (contents + pull-requests write).
+#   * It is minted AFTER all repository code has run, and is exposed only to the git-push /
+#     PR / release steps — never to the `semantic-release`/`cargo`/`npm` steps that execute
+#     repo and dependency code. Those use the default GITHUB_TOKEN (dry-run) or no token.
+#   * checkout uses persist-credentials: false so no token is left on disk during a build.
+#   * The App token is required for push/PR/release specifically because events created with
+#     the default GITHUB_TOKEN do not trigger the downstream publish workflows.
+#
 # The App token only ever pushes to `autorelease/*` branches and opens/closes PRs — it
 # never commits to main — so the App can be removed from the main-branch ruleset bypass.
 
@@ -60,9 +70,10 @@ on:
         description: "true when this run published a release (Phase B)."
         value: ${{ jobs.release.outputs.released }}
 
+# For the default GITHUB_TOKEN, used only by the semantic-release dry-run (version compute).
+# The privileged operations use the separately-minted, repo-scoped App token below.
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   release:
@@ -73,18 +84,13 @@ jobs:
       next_release_version: ${{ steps.version.outputs.value }}
       released: ${{ steps.detect.outputs.phase == 'publish' }}
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
-        with:
-          app-id: ${{ secrets.app_id }}
-          private-key: ${{ secrets.app_private_key }}
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
+          # Do not persist any credential on disk: repo/dependency code (cargo, npm) runs
+          # in later steps and must not be able to read a token from .git/config.
+          persist-credentials: false
 
       - name: Detect release phase
         id: detect
@@ -113,33 +119,7 @@ jobs:
             echo "No release commit in push -> prepare phase"
           fi
 
-      # ───────────────────────── Phase B: publish ─────────────────────────
-      - name: Create tag and GitHub Release
-        if: steps.detect.outputs.phase == 'publish'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          VERSION: ${{ steps.detect.outputs.version }}
-          TAG_PREFIX: ${{ inputs.tag_prefix }}
-        run: |
-          set -euo pipefail
-          tag="${TAG_PREFIX}${VERSION}"
-          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
-            echo "Tag ${tag} already exists; nothing to publish."
-            exit 0
-          fi
-          notes_file="$(mktemp)"
-          if [ -f CHANGELOG.md ]; then
-            # Grab the newest version section (first version header up to the next one).
-            awk '/^#{1,3} \[?[0-9]/{n++; if (n>1) exit} n>=1{print}' CHANGELOG.md > "$notes_file" || true
-          fi
-          if [ -s "$notes_file" ]; then
-            gh release create "$tag" --target main --title "$tag" --notes-file "$notes_file"
-          else
-            gh release create "$tag" --target main --title "$tag" --generate-notes
-          fi
-          echo "Published release ${tag}"
-
-      # ───────────────────────── Phase A: prepare ─────────────────────────
+      # ─────────── Phase A: compute + build the release branch (no App token) ───────────
       - name: Setup Node.js
         if: steps.detect.outputs.phase == 'prepare'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
@@ -172,36 +152,30 @@ jobs:
         id: dryrun
         if: steps.detect.outputs.phase == 'prepare'
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Default repo-scoped token, not the App key — this step executes the repo's
+          # release.config.js. It stays empty in VERIFY_RELEASE_VERSION when no release.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # The repo's release.config.js verifyReleaseCmd writes VERIFY_RELEASE_VERSION to
-          # this step's $GITHUB_OUTPUT. It stays empty when no release is warranted.
           npx semantic-release --dry-run ${{ inputs.args }}
 
-      - name: Open release PR
+      - name: Build release branch
+        id: build
         if: steps.detect.outputs.phase == 'prepare' && steps.dryrun.outputs.VERIFY_RELEASE_VERSION != ''
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # No token in this step: it runs repo + dependency code (cargo, npm scripts).
           VERSION: ${{ steps.dryrun.outputs.VERIFY_RELEASE_VERSION }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # 1. Close any stale open release PRs (and delete their branches) so at most one
-          #    release PR exists at a time. Done before pushing the new branch to avoid
-          #    deleting the branch we are about to create.
-          gh label create autorelease --color FBCA04 --description "Automated release PR" --force >/dev/null 2>&1 || true
-          for n in $(gh pr list --label autorelease --state open --json number --jq '.[].number'); do
-            echo "Closing stale release PR #${n}"
-            gh pr close "$n" --delete-branch || true
-          done
-
-          # 2. Recreate the version bump + CHANGELOG on a fresh branch, reusing the repo's
-          #    own prepareCmd (extracted from release.config.js — single source of truth).
           branch="autorelease/v${VERSION}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
           git switch -c "$branch"
+
+          # Reuse the repo's own version bump, extracted from release.config.js so there is
+          # a single source of truth.
           if [ -f release.config.js ]; then
             # The node script intentionally contains the literal JS string
             # "${nextRelease.version}" (the placeholder to substitute), not a shell var.
@@ -220,8 +194,7 @@ jobs:
             fi
           fi
 
-          # 3. Generate release notes with the same preset semantic-release uses and
-          #    prepend them to CHANGELOG.md.
+          # Release notes via the same preset semantic-release uses; prepend to CHANGELOG.
           npx conventional-changelog -p conventionalcommits -r 1 > /tmp/notes.md || true
           if [ -s /tmp/notes.md ]; then
             touch CHANGELOG.md
@@ -229,20 +202,79 @@ jobs:
             mv /tmp/changelog.new CHANGELOG.md
           fi
 
-          # 4. Commit (no [skip ci] — the merge must trigger the publish phase) and push.
+          # Commit locally (no token needed). No [skip ci]: the merge must trigger publish.
           git add -A
           git commit -m "chore(release): ${VERSION}"
-          git push -f origin "$branch"
 
-          # 5. Open the fresh release PR.
+      # ─────────── Mint the App token only after all repo code has run ───────────
+      - name: Generate app token
+        id: app-token
+        if: steps.detect.outputs.phase == 'publish' || steps.dryrun.outputs.VERIFY_RELEASE_VERSION != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+          # Scoped to this repository only (default) and to the minimum permissions needed.
+          permission-contents: write
+          permission-pull-requests: write
+
+      # ─────────── Phase A: open the release PR (App token, no repo code) ───────────
+      - name: Open release PR
+        if: steps.detect.outputs.phase == 'prepare' && steps.dryrun.outputs.VERIFY_RELEASE_VERSION != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.dryrun.outputs.VERIFY_RELEASE_VERSION }}
+          BRANCH: ${{ steps.build.outputs.branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Close any stale open release PRs (and delete their branches) first, so we never
+          # delete the branch we are about to push.
+          gh label create autorelease --color FBCA04 --description "Automated release PR" --force >/dev/null 2>&1 || true
+          for n in $(gh pr list --label autorelease --state open --json number --jq '.[].number'); do
+            echo "Closing stale release PR #${n}"
+            gh pr close "$n" --delete-branch || true
+          done
+
+          # Push the release branch with the App token via an explicit remote (no persisted
+          # credentials). The token is masked in logs.
+          git push -f "https://x-access-token:${TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${BRANCH}"
+
           body_args=(--body "Automated release for version ${VERSION}. Merging this PR tags the release and triggers publishing.")
           if [ -s /tmp/notes.md ]; then
             body_args=(--body-file /tmp/notes.md)
           fi
-          gh pr create --base main --head "$branch" \
+          gh pr create --base main --head "$BRANCH" \
             --title "chore(release): ${VERSION}" \
             --label autorelease \
             "${body_args[@]}"
+
+      # ─────────── Phase B: publish (App token, no repo code) ───────────
+      - name: Create tag and GitHub Release
+        if: steps.detect.outputs.phase == 'publish'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.detect.outputs.version }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
+        run: |
+          set -euo pipefail
+          tag="${TAG_PREFIX}${VERSION}"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists; nothing to publish."
+            exit 0
+          fi
+          notes_file="$(mktemp)"
+          if [ -f CHANGELOG.md ]; then
+            # Grab the newest version section (first version header up to the next one).
+            awk '/^#{1,3} \[?[0-9]/{n++; if (n>1) exit} n>=1{print}' CHANGELOG.md > "$notes_file" || true
+          fi
+          if [ -s "$notes_file" ]; then
+            gh release create "$tag" --target main --title "$tag" --notes-file "$notes_file"
+          else
+            gh release create "$tag" --target main --title "$tag" --generate-notes
+          fi
+          echo "Published release ${tag}"
 
       - name: Resolve output version
         id: version


### PR DESCRIPTION
Reusable release workflow that opens a **release PR** for human review instead of pushing the version bump to main. Built on `release-please`.

## Behaviour
release-please handles both phases in one run (triggered by the caller's push to main):
- **normal push** → creates/updates the release PR (version bump + `Cargo.toml`/`Cargo.lock` + CHANGELOG, from Conventional Commits)
- **release PR merged** → creates the tag + GitHub Release, which triggers each repo's existing `release: published` publish workflows (crates.io, npm, binaries, images)

## Why release-please over semantic-release
`release-v2` pushes the release commit straight to main via `@semantic-release/git`, which requires the App to bypass the main-branch ruleset. Forcing semantic-release into a PR model needs fragile glue (dry-run parsing, config extraction, hand-rolled tag creation). release-please is built for the PR model: it maintains the PR natively, keeps it updated as commits land, and only tags on merge.

## Token handling
- App token is **repo-scoped** (default) and limited to `contents` + `pull-requests` + `issues` write.
- release-please edits manifests/lockfiles directly — **no `cargo`/`npm` build runs**, so no dependency `build.rs`/install script executes during a release and the token is never exposed to one.
- The App token (not the default `GITHUB_TOKEN`) is required so the release PR gets CI and the published release triggers downstream workflows.
- The token only manages the release PR and creates the tag/Release — it never commits to main, so the App can be dropped from the ruleset bypass.

## Requires
- The App needs **`issues: write`** added (currently missing) for release-please label management.
- Each consumer repo adds `release-please-config.json` + `.release-please-manifest.json` (replacing `release.config.js`), using `release-type: rust` + the `cargo-workspace` plugin (updates `Cargo.lock`) and `include-v-in-tags: false` (keeps bare version tags).

## Behavioural deltas vs semantic-release (agreed)
- `refactor`/`security`/`style` commits no longer trigger a release on their own (only `feat`/`fix`/breaking do).
- Breaking changes use `feat!:` / `BREAKING CHANGE:` rather than a `breaking:` type.

Not yet exercised end-to-end; `token-quoter` is the planned first cutover / validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
