### PR TITLE
security: use GITHUB_TOKEN for PR title validation

### DIFF
--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -12,26 +12,27 @@ on:
         type: number
         default: 30
     secrets:
+      # Deprecated: the title check now uses the default GITHUB_TOKEN. Kept optional so
+      # existing callers that still pass them do not break. Remove from callers, then
+      # delete these.
       app_id:
-        required: true
+        required: false
       app_private_key:
-        required: true
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   main:
     runs-on: "${{ inputs.runs_on }}"
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
-      - name: Generate a token
-        id: generate-token
-        uses: getsentry/action-github-app-token@v2
-        with:
-          app_id: ${{ secrets.app_id }}
-          private_key: ${{ secrets.app_private_key }}
-
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           types: |
             breaking


### PR DESCRIPTION
The PR-title validation reusable minted a token from the App private key. Its callers (`tycho`, `fynd`, `token-quoter`) invoke it on `pull_request_target`, so the App key was being minted in fork-triggered runs — the only remaining fork-reachable use of the key.

A title lint only needs to read the PR title, so this switches it to the default `GITHUB_TOKEN` and drops the app-token step entirely.

## Changes
- Remove the `getsentry/action-github-app-token` step; use `github.token`.
- SHA-pin `amannn/action-semantic-pull-request` (was the mutable `@v5` tag) and bump to v6.1.1.
- Add minimal `permissions` (`pull-requests: read`).
- Keep `app_id` / `app_private_key` as optional secrets so callers passing them don't break; they'll be removed from callers in follow-up, then from here.

No behavioural change to title validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
