### PR TITLE
ci: dispatch release-v3 by language (release-plz for rust)

### DIFF
--- a/.github/workflows/release-v3.yaml
+++ b/.github/workflows/release-v3.yaml
@@ -1,26 +1,16 @@
-name: Release v3 (release-please)
+name: Release v3
 
-# PR-based release flow built on release-please. Unlike release-v2 (semantic-release +
-# @semantic-release/git, which pushes the version bump straight to main), v3 opens a
-# release PR for human review and never commits to main.
+# Single entry point for PR-based releases. It never commits to main: a normal push
+# opens/updates a release PR; merging that PR tags and creates the GitHub Release.
 #
-# release-please handles both phases in a single run, triggered by the caller's push to
-# main:
-#   * normal push        -> create or update the release PR (version bump + CHANGELOG +
-#                           Cargo.lock, computed from Conventional Commits)
-#   * release PR merged   -> create the tag + GitHub Release, which triggers the repo's
-#                           existing `release: published` publish workflows
+# Dispatches by language (auto-detected from a root Cargo.toml, or forced via `language`):
+#   * rust    -> release-plz  (native Cargo workspace + Cargo.lock handling, crates.io
+#                              publish in dependency order)
+#   * generic -> release-please
 #
-# It edits manifests/lockfiles directly (no cargo/npm build), so no repository or
-# dependency code runs here and the App token is never exposed to a build script.
-#
-# Each consumer repo supplies its own `release-please-config.json` and
-# `.release-please-manifest.json`. The App token is used (not the default GITHUB_TOKEN)
-# so the release PR gets CI and the published release triggers downstream workflows —
-# events created with GITHUB_TOKEN do not trigger other workflows.
-#
-# The App token only opens/updates the release PR and creates the tag/Release — it never
-# commits to main — so the App can be removed from the main-branch ruleset bypass.
+# Both engines mint a repo-scoped App token (so the release PR gets CI and the published
+# release triggers downstream workflows — GITHUB_TOKEN-created events do not). Outputs are
+# normalised so callers gate build/deploy the same way regardless of engine.
 
 on:
   workflow_call:
@@ -29,54 +19,92 @@ on:
         required: false
         type: string
         default: ubuntu-latest
+      language:
+        description: "auto | rust | generic. auto picks rust when a root Cargo.toml exists."
+        required: false
+        type: string
+        default: auto
       target_branch:
         required: false
         type: string
         default: main
       config_file:
+        description: release-please config (generic engine).
         required: false
         type: string
         default: release-please-config.json
       manifest_file:
+        description: release-please manifest (generic engine).
         required: false
         type: string
         default: .release-please-manifest.json
+      release_plz_config:
+        description: release-plz config (rust engine).
+        required: false
+        type: string
+        default: release-plz.toml
     secrets:
       app_id:
         required: true
       app_private_key:
         required: true
+      cargo_registry_token:
+        description: crates.io token; required only when the rust engine publishes crates.
+        required: false
     outputs:
       releases_created:
-        description: "true if any release was created (a release PR was merged this run)."
-        value: ${{ jobs.release-please.outputs.releases_created }}
-      release_created:
-        description: "true if the root component was released."
-        value: ${{ jobs.release-please.outputs.release_created }}
-      tag_name:
-        description: The tag of the created release (empty when no release).
-        value: ${{ jobs.release-please.outputs.tag_name }}
+        description: "'true' when this run created a release (a release PR was merged)."
+        value: ${{ jobs.release-plz-release.outputs.releases_created || jobs.release-please.outputs.releases_created }}
       version:
         description: The released version (empty when no release).
-        value: ${{ jobs.release-please.outputs.version }}
-      paths_released:
-        description: JSON array of package paths that were released.
-        value: ${{ jobs.release-please.outputs.paths_released }}
+        value: ${{ jobs.release-plz-release.outputs.version || jobs.release-please.outputs.version }}
+      tag_name:
+        description: The tag of the created release (empty when no release).
+        value: ${{ jobs.release-plz-release.outputs.tag_name || jobs.release-please.outputs.tag_name }}
 
-# The default GITHUB_TOKEN is unused: every write goes through the repo-scoped App token.
+# For the default GITHUB_TOKEN (used only by the detect step); every write uses the App token.
 permissions:
   contents: read
 
 jobs:
-  release-please:
-    name: Release Please
+  detect:
+    name: Detect release engine
     runs-on: ${{ inputs.runs_on }}
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
-      paths_released: ${{ steps.release.outputs.paths_released }}
+      engine: ${{ steps.pick.outputs.engine }}
+    steps:
+      - name: Pick engine
+        id: pick
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LANGUAGE: ${{ inputs.language }}
+          REPO: ${{ github.repository }}
+          REF: ${{ inputs.target_branch }}
+        run: |
+          set -euo pipefail
+          case "$LANGUAGE" in
+            rust|generic) engine="$LANGUAGE" ;;
+            auto)
+              if gh api "repos/${REPO}/contents/Cargo.toml?ref=${REF}" >/dev/null 2>&1; then
+                engine=rust
+              else
+                engine=generic
+              fi ;;
+            *) echo "Unknown language input: $LANGUAGE" >&2; exit 1 ;;
+          esac
+          echo "engine=$engine" >> "$GITHUB_OUTPUT"
+          echo "Release engine: $engine"
+
+  # ───────────────────────── rust: release-plz ─────────────────────────
+  # Maintains the release PR. Runs on every push; release-plz decides what to update.
+  release-plz-pr:
+    name: release-plz (PR)
+    needs: detect
+    if: needs.detect.outputs.engine == 'rust'
+    runs-on: ${{ inputs.runs_on }}
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - name: Generate app token
         id: app-token
@@ -84,13 +112,81 @@ jobs:
         with:
           app-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.app_private_key }}
-          # Scoped to this repository only (default) and to the minimum permissions
-          # release-please needs: contents (bump/tag/release), pull-requests (release PR),
-          # issues (manage the autorelease labels).
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1  # stable
+      - name: release-plz release-pr
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9  # v0.5.131
+        with:
+          command: release-pr
+          config: ${{ inputs.release_plz_config }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+  # Publishes/tags/releases anything unpublished (i.e. when a release PR was merged).
+  release-plz-release:
+    name: release-plz (release)
+    needs: detect
+    if: needs.detect.outputs.engine == 'rust'
+    runs-on: ${{ inputs.runs_on }}
+    outputs:
+      releases_created: ${{ steps.rp.outputs.releases_created }}
+      version: ${{ steps.rp.outputs.releases_created == 'true' && fromJSON(steps.rp.outputs.releases)[0].version || '' }}
+      tag_name: ${{ steps.rp.outputs.releases_created == 'true' && fromJSON(steps.rp.outputs.releases)[0].tag || '' }}
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1  # stable
+      - name: release-plz release
+        id: rp
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9  # v0.5.131
+        with:
+          command: release
+          config: ${{ inputs.release_plz_config }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
+
+  # ───────────────────────── generic: release-please ─────────────────────────
+  release-please:
+    name: release-please
+    needs: detect
+    if: needs.detect.outputs.engine == 'generic'
+    runs-on: ${{ inputs.runs_on }}
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      version: ${{ steps.release.outputs.version }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0


### PR DESCRIPTION
Makes `release-v3` a single entry point that dispatches by language.

## Why
release-please cannot handle our Rust workspaces: verified in its source that the Rust updater rejects workspace manifests and the `cargo-workspace` plugin errors on `version.workspace = true` (it requires an explicit per-crate `[package].version`). `fynd` and `tycho` both use inherited workspace versions, and release-please also can't update their `Cargo.lock`.

`release-plz` is Rust-native: it runs `cargo` under the hood, so workspace inheritance and `Cargo.lock` updates work by construction, and it publishes workspace crates in dependency order (subsuming tycho's hand-maintained publish waves).

## Behaviour
- **`rust`** (auto-detected from a root `Cargo.toml`, or `language: rust`) → release-plz: `release-pr` maintains the release PR; `release` tags + publishes + creates the GitHub Release on merge.
- **`generic`** → release-please (unchanged).
- Neither commits to main.

Outputs are normalised across both engines — `releases_created`, `version`, `tag_name` — so a caller's build/deploy jobs gate the same way regardless of engine.

## Notes
- Both engines mint a repo-scoped App token (`contents` + `pull-requests` + `issues` write). The App still needs `issues: write` added.
- `release-plz` runs `cargo`; set `semver_check = false` in `release-plz.toml` to keep the PR job to metadata/lockfile only (no `build.rs` execution).
- Publishing crates uses `cargo_registry_token` (optional; services set `publish = false` in `release-plz.toml`).
- Supersedes the release-please-only `release-v3` from #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
