### PR TITLE
fix(release-v3): set rust toolchain channel for SHA-pinned dtolnay action

### DIFF
--- a/.github/workflows/release-v3.yaml
+++ b/.github/workflows/release-v3.yaml
@@ -122,6 +122,8 @@ jobs:
           persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1  # stable
+        with:
+          toolchain: stable
       - name: release-plz release-pr
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9  # v0.5.131
         with:
@@ -157,6 +159,8 @@ jobs:
           persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1  # stable
+        with:
+          toolchain: stable
       - name: release-plz release
         id: rp
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9  # v0.5.131


### PR DESCRIPTION
release-v3's release-plz jobs failed with `error: invalid toolchain name ''`. `dtolnay/rust-toolchain` is SHA-pinned, so it can't infer the channel from the ref; without an explicit `toolchain:` input, `rustc +` runs with an empty toolchain. Adds `toolchain: stable` to both toolchain steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)