### PR TITLE
fix(release): keep Git LFS filters out of release-plz checkouts

### DIFF
--- a/.github/workflows/release-v3.yaml
+++ b/.github/workflows/release-v3.yaml
@@ -115,6 +115,18 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+      # release-plz checks old commits out in a temp clone to diff each package. If any commit
+      # in that range holds a file that .gitattributes marks `filter=lfs` but that was committed
+      # as raw content, the clean filter rewrites it to a pointer on every status, so the file
+      # reads as modified and release-plz cannot check back out to HEAD. Passing blobs through
+      # untouched keeps the tree clean; release-plz diffs packaged files, not LFS content.
+      - name: Pass Git LFS blobs through unfiltered
+        run: |
+          set -euo pipefail
+          git config --global filter.lfs.smudge cat
+          git config --global filter.lfs.clean cat
+          git config --global filter.lfs.process ""
+          git config --global filter.lfs.required false
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -152,6 +164,18 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+      # release-plz checks old commits out in a temp clone to diff each package. If any commit
+      # in that range holds a file that .gitattributes marks `filter=lfs` but that was committed
+      # as raw content, the clean filter rewrites it to a pointer on every status, so the file
+      # reads as modified and release-plz cannot check back out to HEAD. Passing blobs through
+      # untouched keeps the tree clean; release-plz diffs packaged files, not LFS content.
+      - name: Pass Git LFS blobs through unfiltered
+        run: |
+          set -euo pipefail
+          git config --global filter.lfs.smudge cat
+          git config --global filter.lfs.clean cat
+          git config --global filter.lfs.process ""
+          git config --global filter.lfs.required false
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:


### PR DESCRIPTION
 .gitattributes marks `fynd-core/tests/fixtures/*.json.zst` as filter=lfs, but commit bbfe41c8 committed the fixture as raw 771 KB content, bypassing the filter. 32a25128 fixed HEAD by re-adding it as a pointer, but every commit in between still holds a raw blob under an LFS attribute.

Checking out any commit in that range leaves the worktree permanently dirty: git writes the raw bytes, then the LFS clean filter rewrites them to a pointer on every status, which never matches the stored blob. release-plz checks old commits out in a temp clone to diff each package, lands in that range, and can't get back to main.

Route LFS blobs through `cat` in both release-plz jobs so checkouts are byte-exact to the stored blobs.

